### PR TITLE
Add CI pipeline with Clarinet check and frontend build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  contract-check:
+    name: Clarinet Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Clarinet
+        uses: hirosystems/clarinet-actions/setup@v1
+
+      - name: Check contracts
+        run: clarinet check
+
+  frontend-build:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build
+        working-directory: frontend
+        run: npm run build


### PR DESCRIPTION
There was no CI running on this repo. Contract and frontend changes could be merged without any automated validation.

Adds a GitHub Actions workflow (.github/workflows/ci.yml) that triggers on push and PR to main:

1. **contract-check** — Installs Clarinet via hirosystems/clarinet-actions and runs clarinet check to validate Clarity syntax and types
2. **frontend-build** — Sets up Node 20, installs frontend deps, and runs npm run build to catch compile-time errors

This prevents broken contracts or frontend code from reaching main.

Closes #26