### PR TITLE
Add caching layer for contract read calls

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import { useToast } from './hooks/useToast'
 import { useTheme } from './hooks/useTheme'
 import { useTransactionTracker } from './hooks/useTransactionTracker'
 import { pinMessage, reactToMessage } from './utils/contractCalls'
+import { invalidateReadCache } from './utils/contractReads'
 import { parseClarityError } from './utils/errors'
 import './App.css'
 
@@ -24,6 +25,7 @@ function App() {
   const { theme, toggleTheme } = useTheme()
 
   const handleRefresh = () => {
+    invalidateReadCache()
     refreshMessages()
     refreshStats()
   }

--- a/frontend/src/__tests__/utils/cache.test.js
+++ b/frontend/src/__tests__/utils/cache.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import ContractReadCache from '../../utils/cache'
+
+describe('ContractReadCache', () => {
+  let cache
+
+  beforeEach(() => {
+    cache = new ContractReadCache(100) // 100ms TTL for fast tests
+  })
+
+  it('fetches and caches a value', async () => {
+    const fetcher = vi.fn().mockResolvedValue(42)
+
+    const first = await cache.get('key', fetcher)
+    const second = await cache.get('key', fetcher)
+
+    expect(first).toBe(42)
+    expect(second).toBe(42)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-fetches after TTL expires', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce('old')
+      .mockResolvedValueOnce('new')
+
+    await cache.get('key', fetcher)
+
+    // Wait for TTL * 2 (stale window also expires)
+    await new Promise((r) => setTimeout(r, 210))
+
+    const result = await cache.get('key', fetcher)
+    expect(result).toBe('new')
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns stale data while revalidating', async () => {
+    let resolveSecond
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce('stale-value')
+      .mockImplementationOnce(() => new Promise((r) => { resolveSecond = r }))
+
+    await cache.get('key', fetcher)
+
+    // Wait past TTL but within 2x TTL (stale window)
+    await new Promise((r) => setTimeout(r, 110))
+
+    const result = await cache.get('key', fetcher)
+    expect(result).toBe('stale-value') // returns stale immediately
+    expect(fetcher).toHaveBeenCalledTimes(2) // background fetch started
+
+    // Resolve the background fetch
+    resolveSecond('fresh-value')
+    await new Promise((r) => setTimeout(r, 10))
+
+    const fresh = await cache.get('key', fetcher)
+    expect(fresh).toBe('fresh-value')
+  })
+
+  it('deduplicates concurrent requests for the same key', async () => {
+    let resolvePromise
+    const fetcher = vi.fn().mockImplementation(
+      () => new Promise((r) => { resolvePromise = r })
+    )
+
+    const p1 = cache.get('key', fetcher)
+    const p2 = cache.get('key', fetcher)
+
+    resolvePromise('value')
+    const [r1, r2] = await Promise.all([p1, p2])
+
+    expect(r1).toBe('value')
+    expect(r2).toBe('value')
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns stale data on fetch error', async () => {
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce('cached')
+      .mockRejectedValueOnce(new Error('network'))
+
+    await cache.get('key', fetcher)
+
+    // Wait for full expiry
+    await new Promise((r) => setTimeout(r, 210))
+
+    const result = await cache.get('key', fetcher)
+    expect(result).toBe('cached') // fallback to stale
+  })
+
+  it('throws if no stale data and fetch fails', async () => {
+    const fetcher = vi.fn().mockRejectedValue(new Error('fail'))
+
+    await expect(cache.get('key', fetcher)).rejects.toThrow('fail')
+  })
+
+  it('invalidate removes a specific key', async () => {
+    const fetcher = vi.fn().mockResolvedValue('value')
+
+    await cache.get('key', fetcher)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+
+    cache.invalidate('key')
+
+    await cache.get('key', fetcher)
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+
+  it('invalidatePrefix removes matching keys', async () => {
+    const fetcher = vi.fn().mockResolvedValue('v')
+
+    await cache.get('message:1', fetcher)
+    await cache.get('message:2', fetcher)
+    await cache.get('stats', fetcher)
+
+    cache.invalidatePrefix('message:')
+
+    expect(cache.size).toBe(1) // only 'stats' remains
+  })
+
+  it('invalidateAll clears everything', async () => {
+    const fetcher = vi.fn().mockResolvedValue('v')
+
+    await cache.get('a', fetcher)
+    await cache.get('b', fetcher)
+    await cache.get('c', fetcher)
+
+    cache.invalidateAll()
+    expect(cache.size).toBe(0)
+  })
+
+  it('size returns correct count', async () => {
+    const fetcher = vi.fn().mockResolvedValue('v')
+
+    expect(cache.size).toBe(0)
+
+    await cache.get('x', fetcher)
+    expect(cache.size).toBe(1)
+
+    await cache.get('y', fetcher)
+    expect(cache.size).toBe(2)
+  })
+})

--- a/frontend/src/utils/cache.js
+++ b/frontend/src/utils/cache.js
@@ -1,0 +1,128 @@
+/**
+ * In-memory cache for contract read calls.
+ *
+ * Uses a TTL (time-to-live) approach with stale-while-revalidate semantics:
+ * - If data is fresh (< TTL), return it immediately.
+ * - If data is stale (> TTL but < 2x TTL), return stale data and trigger
+ *   a background revalidation.
+ * - If data is expired (> 2x TTL), wait for a fresh fetch.
+ *
+ * Call `invalidate(key)` or `invalidateAll()` after the user submits a
+ * transaction so the next read picks up the new on-chain state.
+ */
+
+const DEFAULT_TTL = 120_000 // 2 minutes (~1 Stacks block)
+
+class ContractReadCache {
+  constructor(ttl = DEFAULT_TTL) {
+    this.ttl = ttl
+    this.store = new Map()
+    this.inflight = new Map()
+  }
+
+  /**
+   * Get a cached value or fetch it.
+   *
+   * @param {string} key - Cache key (e.g. "message:5", "stats")
+   * @param {Function} fetcher - Async function that returns the fresh value
+   * @returns {Promise<any>} The cached or freshly fetched value
+   */
+  async get(key, fetcher) {
+    const entry = this.store.get(key)
+    const now = Date.now()
+
+    if (entry) {
+      const age = now - entry.timestamp
+
+      // Fresh — return immediately
+      if (age < this.ttl) {
+        return entry.value
+      }
+
+      // Stale but not expired — return stale, revalidate in background
+      if (age < this.ttl * 2) {
+        this._revalidate(key, fetcher)
+        return entry.value
+      }
+    }
+
+    // Expired or missing — fetch synchronously
+    return this._fetch(key, fetcher)
+  }
+
+  /**
+   * Fetch and store a value. Deduplicates concurrent requests for the same key.
+   */
+  async _fetch(key, fetcher) {
+    // Deduplicate inflight requests
+    if (this.inflight.has(key)) {
+      return this.inflight.get(key)
+    }
+
+    const promise = fetcher()
+      .then((value) => {
+        this.store.set(key, { value, timestamp: Date.now() })
+        this.inflight.delete(key)
+        return value
+      })
+      .catch((err) => {
+        this.inflight.delete(key)
+        // If we have stale data, return it on error
+        const stale = this.store.get(key)
+        if (stale) return stale.value
+        throw err
+      })
+
+    this.inflight.set(key, promise)
+    return promise
+  }
+
+  /**
+   * Background revalidation — does not block the caller.
+   */
+  _revalidate(key, fetcher) {
+    if (this.inflight.has(key)) return
+    this._fetch(key, fetcher).catch(() => {
+      // Swallow errors during background revalidation
+    })
+  }
+
+  /**
+   * Invalidate a specific cache entry.
+   * @param {string} key
+   */
+  invalidate(key) {
+    this.store.delete(key)
+  }
+
+  /**
+   * Invalidate all entries matching a prefix.
+   * @param {string} prefix - e.g. "message:" to clear all message entries
+   */
+  invalidatePrefix(prefix) {
+    for (const key of this.store.keys()) {
+      if (key.startsWith(prefix)) {
+        this.store.delete(key)
+      }
+    }
+  }
+
+  /**
+   * Clear the entire cache. Use after a transaction confirms.
+   */
+  invalidateAll() {
+    this.store.clear()
+  }
+
+  /**
+   * Get the number of entries in the cache.
+   */
+  get size() {
+    return this.store.size
+  }
+}
+
+// Singleton instance for the app
+export const contractCache = new ContractReadCache()
+
+export default ContractReadCache


### PR DESCRIPTION
Every page load and component mount fires multiple API calls to the Stacks node. This adds an in-memory cache with stale-while-revalidate semantics to reduce redundant requests.

## How it works

`ContractReadCache` stores read results with a 2-minute TTL (roughly one Stacks block):

- **Fresh** (< TTL): returns cached value, no network call
- **Stale** (TTL to 2x TTL): returns cached value immediately, revalidates in background
- **Expired** (> 2x TTL): fetches fresh data before returning

Additional features:
- Deduplicates concurrent requests for the same key
- Falls back to stale data if a network request fails
- `invalidateAll()` clears the cache after transaction confirmation

## Cached functions

| Function | Cache key |
|---|---|
| `fetchMessage(id)` | `message:{id}` |
| `fetchTotalMessages()` | `totalMessages` |
| `fetchTotalFees()` | `totalFees` |
| `fetchContractStats()` | `contractStats` |
| `fetchUserStats(addr)` | `userStats:{addr}` |

## Cache invalidation

When a transaction confirms, `handleRefresh()` in App.jsx calls `invalidateReadCache()` to clear all cached data before refreshing messages and stats.

## Tests

10 unit tests cover TTL expiry, stale-while-revalidate behavior, request deduplication, error fallback, and all invalidation methods.

Closes #32