### PR TITLE
Rewrite CONTRACT_API.md with full v3 function reference

### DIFF
--- a/docs/CONTRACT_API.md
+++ b/docs/CONTRACT_API.md
@@ -1,126 +1,680 @@
-# Message Board Contract API
+# Bitchat Contract API Reference
 
-## Contract: `message-board.clar`
+Complete API documentation for the Bitchat message board smart contract on the Stacks blockchain.
 
-### Public Functions
+## Contract Information
 
-#### `post-message`
-Post a new message to the board.
+| Field | Value |
+|-------|-------|
+| **Contract Name** | `message-board-v3` |
+| **Network** | Stacks Mainnet |
+| **Contract Address** | `SP1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK0DYG193.message-board-v3` |
+| **Clarity Version** | 2 |
+| **Max Message Length** | 280 characters (UTF-8) |
+| **Default Expiry** | 144 blocks (~24 hours) |
+
+## Table of Contents
+
+- [Public Functions](#public-functions)
+  - [post-message](#post-message)
+  - [pin-message](#pin-message)
+  - [react-to-message](#react-to-message)
+  - [react-to-message-typed](#react-to-message-typed)
+  - [reply-to-message](#reply-to-message)
+  - [edit-message](#edit-message)
+  - [delete-message](#delete-message)
+  - [set-display-name](#set-display-name)
+- [Owner Functions](#owner-functions)
+  - [withdraw-fees](#withdraw-fees)
+  - [pause-contract / unpause-contract](#pause-contract--unpause-contract)
+  - [propose-ownership-transfer](#propose-ownership-transfer)
+  - [accept-ownership](#accept-ownership)
+  - [cancel-ownership-transfer](#cancel-ownership-transfer)
+  - [Fee Setters](#fee-setters)
+- [Read-Only Functions](#read-only-functions)
+  - [get-message](#get-message)
+  - [get-active-message](#get-active-message)
+  - [is-message-expired](#is-message-expired)
+  - [is-message-pinned](#is-message-pinned)
+  - [is-message-deleted](#is-message-deleted)
+  - [get-user-stats](#get-user-stats)
+  - [get-user-profile](#get-user-profile)
+  - [get-display-name](#get-display-name)
+  - [get-total-messages](#get-total-messages)
+  - [get-total-deleted](#get-total-deleted)
+  - [get-total-edits](#get-total-edits)
+  - [get-total-replies](#get-total-replies)
+  - [get-total-fees-collected](#get-total-fees-collected)
+  - [get-message-nonce](#get-message-nonce)
+  - [get-contract-stats](#get-contract-stats)
+  - [get-page-range](#get-page-range)
+  - [has-user-reacted](#has-user-reacted)
+  - [get-user-reaction-type](#get-user-reaction-type)
+  - [get-reaction-count-by-type](#get-reaction-count-by-type)
+  - [get-reply-parent / is-reply](#get-reply-parent--is-reply)
+  - [get-edit-history](#get-edit-history)
+  - [is-contract-paused](#is-contract-paused)
+  - [get-contract-owner](#get-contract-owner)
+  - [get-proposed-owner](#get-proposed-owner)
+  - [Fee Getters](#fee-getters)
+- [Data Structures](#data-structures)
+- [Error Codes](#error-codes)
+- [Constants](#constants)
+- [Fee Structure](#fee-structure)
+- [Integration Guide](#integration-guide)
+
+---
+
+## Public Functions
+
+### post-message
+
+Posts a new message to the board. Requires a fee payment in STX.
+
+**Signature:**
+```clarity
+(define-public (post-message (content (string-utf8 280))))
+```
 
 **Parameters:**
-- `content` (string-utf8 280): Message content (1-280 characters)
+| Name | Type | Description |
+|------|------|-------------|
+| `content` | `(string-utf8 280)` | Message content, 1-280 UTF-8 characters |
 
-**Returns:** `(response uint uint)`
-- Success: Message ID
-- Error codes: u103 (invalid input)
+**Returns:** `(response uint uint)` -- the new message ID on success
 
-**Fee:** 0.00001 STX
+**Behavior:**
+- Validates content length (1-280 characters)
+- Enforces spam cooldown (6 blocks between posts per user)
+- Charges the current `fee-post-message` (default 10,000 uSTX)
+- Sets expiry to `block-height + 144` (~24 hours by default)
+- Increments `total-messages`, `message-nonce`, and the user's `messages-posted`
+- Contract must not be paused
 
-**Example:**
-```clarity
-(contract-call? .message-board post-message u"Hello Bitchat!")
+**Example (JavaScript):**
+```javascript
+import { openContractCall } from '@stacks/connect';
+import { stringUtf8CV } from '@stacks/transactions';
+
+await openContractCall({
+  contractAddress: 'SP1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK0DYG193',
+  contractName: 'message-board-v3',
+  functionName: 'post-message',
+  functionArgs: [stringUtf8CV('Hello Bitchat!')],
+  postConditionMode: 0x01,
+  onFinish: (data) => console.log('TX:', data.txId),
+});
 ```
 
 ---
 
-#### `pin-message`
-Pin a message for extended visibility.
+### pin-message
+
+Pins an existing message. Only the message author or contract owner can pin.
+
+**Signature:**
+```clarity
+(define-public (pin-message (message-id uint) (duration uint)))
+```
 
 **Parameters:**
-- `message-id` (uint): Message to pin
-- `duration` (uint): Pin duration (144 for 24hr, 432 for 72hr)
+| Name | Type | Description |
+|------|------|-------------|
+| `message-id` | `uint` | ID of the message to pin |
+| `duration` | `uint` | `u144` for 24 hours, `u432` for 72 hours |
 
 **Returns:** `(response bool uint)`
-- Success: true
-- Error codes: u101 (not found), u102 (unauthorized), u103 (invalid input)
 
 **Fees:**
-- 24 hours: 0.00005 STX
-- 72 hours: 0.0001 STX
-
-**Requirements:**
-- Sender must be message author
-- Duration must be 144 or 432 blocks
-
-**Example:**
-```clarity
-(contract-call? .message-board pin-message u0 u144)
-```
+- 24-hour pin (`u144`): `fee-pin-24hr` (default 50,000 uSTX)
+- 72-hour pin (`u432`): `fee-pin-72hr` (default 100,000 uSTX)
 
 ---
 
-#### `react-to-message`
-React to a message (like/upvote).
+### react-to-message
+
+Reacts to a message with a default "like" reaction (type 1). Each user can react once per message.
+
+**Signature:**
+```clarity
+(define-public (react-to-message (message-id uint)))
+```
 
 **Parameters:**
-- `message-id` (uint): Message to react to
+| Name | Type | Description |
+|------|------|-------------|
+| `message-id` | `uint` | ID of the message to react to |
 
 **Returns:** `(response bool uint)`
-- Success: true
-- Error codes: u101 (not found), u105 (already reacted)
 
-**Fee:** 0.000005 STX
+**Fee:** `fee-reaction` (default 5,000 uSTX)
 
-**Requirements:**
-- User cannot react to same message twice
+---
+
+### react-to-message-typed
+
+Reacts to a message with a specific reaction type. Each user can react once per message.
+
+**Signature:**
+```clarity
+(define-public (react-to-message-typed (message-id uint) (rtype uint)))
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `message-id` | `uint` | ID of the message to react to |
+| `rtype` | `uint` | Reaction type: `u1`=like, `u2`=fire, `u3`=laugh, `u4`=sad, `u5`=dislike |
+
+**Returns:** `(response bool uint)`
+
+**Fee:** `fee-reaction` (default 5,000 uSTX)
 
 **Example:**
-```clarity
-(contract-call? .message-board react-to-message u0)
+```javascript
+import { uintCV } from '@stacks/transactions';
+
+// React with "fire" to message #5
+await openContractCall({
+  contractAddress: 'SP1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK0DYG193',
+  contractName: 'message-board-v3',
+  functionName: 'react-to-message-typed',
+  functionArgs: [uintCV(5), uintCV(2)],
+  postConditionMode: 0x01,
+  onFinish: (data) => console.log('TX:', data.txId),
+});
 ```
 
 ---
 
-### Read-Only Functions
+### reply-to-message
 
-#### `get-message`
-Retrieve a message by ID.
+Posts a reply to an existing message. Creates a new message linked to the parent.
 
-**Parameters:**
-- `message-id` (uint): Message identifier
-
-**Returns:** `(optional {...})`
-- Message data or none
-
-#### `get-user-stats`
-Get statistics for a user.
+**Signature:**
+```clarity
+(define-public (reply-to-message (parent-id uint) (content (string-utf8 280))))
+```
 
 **Parameters:**
-- `user` (principal): User address
+| Name | Type | Description |
+|------|------|-------------|
+| `parent-id` | `uint` | ID of the message to reply to |
+| `content` | `(string-utf8 280)` | Reply content, 1-280 UTF-8 characters |
 
-**Returns:** `(optional {...})`
-- User statistics or none
+**Returns:** `(response uint uint)` -- the new reply message ID
 
-#### `get-total-messages`
-Get total message count.
+**Behavior:**
+- Parent message must exist and not be deleted
+- Same validation and fee as `post-message`
+- Sets the reply's `reply-to` field to `parent-id`
+- Increments the parent's `reply-count` and the global `total-replies`
+- The spam cooldown applies the same as regular posts
 
-**Returns:** `(response uint uint)`
+---
 
-#### `get-total-fees-collected`
-Get total fees collected by contract.
+### edit-message
 
-**Returns:** `(response uint uint)`
+Edits the content of an existing message. Only the author can edit.
 
-#### `get-message-nonce`
-Get current message ID counter.
-
-**Returns:** `(response uint uint)`
-
-#### `has-user-reacted`
-Check if user has reacted to a message.
+**Signature:**
+```clarity
+(define-public (edit-message (message-id uint) (new-content (string-utf8 280))))
+```
 
 **Parameters:**
-- `message-id` (uint): Message identifier
-- `user` (principal): User address
+| Name | Type | Description |
+|------|------|-------------|
+| `message-id` | `uint` | ID of the message to edit |
+| `new-content` | `(string-utf8 280)` | New content, 1-280 UTF-8 characters |
+
+**Returns:** `(response bool uint)`
+
+**Behavior:**
+- Only the original author can edit their message
+- Maximum of 10 edits per message (`max-edit-count`)
+- Previous content is stored in `edit-history` map
+- Sets `edited: true` and increments `edit-count` on the message
+- Increments global `total-edits`
+- Cannot edit deleted messages
+- No fee charged for editing
+
+---
+
+### delete-message
+
+Soft-deletes a message. Only the author or contract owner can delete.
+
+**Signature:**
+```clarity
+(define-public (delete-message (message-id uint)))
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `message-id` | `uint` | ID of the message to delete |
+
+**Returns:** `(response bool uint)`
+
+**Behavior:**
+- Marks message as `deleted: true` (content remains on-chain)
+- Cannot delete an already-deleted message (returns `err-already-deleted`)
+- Increments global `total-deleted`
+- No fee charged
+
+---
+
+### set-display-name
+
+Sets a display name for the calling user.
+
+**Signature:**
+```clarity
+(define-public (set-display-name (name (string-utf8 50))))
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `name` | `(string-utf8 50)` | Display name, 1-50 UTF-8 characters |
+
+**Returns:** `(response bool uint)`
+
+**Behavior:**
+- Contract must not be paused
+- Cannot be empty
+- Stored in the `user-profiles` map
+- No fee charged
+
+---
+
+## Owner Functions
+
+These functions can only be called by the contract owner.
+
+### withdraw-fees
+
+Withdraws collected fees from the contract.
+
+**Signature:**
+```clarity
+(define-public (withdraw-fees (amount uint) (recipient principal)))
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `amount` | `uint` | Amount in microSTX to withdraw |
+| `recipient` | `principal` | Address to send the fees to |
+
+---
+
+### pause-contract / unpause-contract
+
+Toggles the paused state of the contract. When paused, most public functions are disabled.
+
+```clarity
+(define-public (pause-contract))
+(define-public (unpause-contract))
+```
+
+---
+
+### propose-ownership-transfer
+
+Proposes a new owner. The proposed owner must call `accept-ownership` to complete the transfer.
+
+```clarity
+(define-public (propose-ownership-transfer (new-owner principal)))
+```
+
+### accept-ownership
+
+Called by the proposed owner to accept the ownership transfer.
+
+```clarity
+(define-public (accept-ownership))
+```
+
+### cancel-ownership-transfer
+
+Cancels a pending ownership transfer.
+
+```clarity
+(define-public (cancel-ownership-transfer))
+```
+
+---
+
+### Fee Setters
+
+The contract owner can adjust fees within the allowed range (`u1000` to `u10000000` microSTX).
+
+```clarity
+(define-public (set-fee-post-message (new-fee uint)))
+(define-public (set-fee-pin-24hr (new-fee uint)))
+(define-public (set-fee-pin-72hr (new-fee uint)))
+(define-public (set-fee-reaction (new-fee uint)))
+```
+
+Each setter validates `min-fee <= new-fee <= max-fee` and returns `err-invalid-input` if out of range.
+
+---
+
+## Read-Only Functions
+
+### get-message
+
+Returns the full message record including all metadata.
+
+**Signature:**
+```clarity
+(define-read-only (get-message (message-id uint)))
+```
+
+**Returns:** `(optional { author, content, timestamp, block-height, expires-at, pinned, pin-expires-at, reaction-count, deleted, edited, edit-count, reply-to, reply-count })`
+
+Returns `none` if the message ID has never been used.
+
+---
+
+### get-active-message
+
+Returns a message only if it has not been deleted and has not expired.
+
+**Signature:**
+```clarity
+(define-read-only (get-active-message (message-id uint)))
+```
+
+**Returns:** `(optional { ... })` -- same shape as `get-message`, or `none` if deleted/expired/not found
+
+---
+
+### is-message-expired
+
+Checks whether a message has passed its expiry block.
+
+```clarity
+(define-read-only (is-message-expired (message-id uint)))
+```
+
+**Returns:** `bool` -- `true` if `block-height >= expires-at`, or `true` if message not found
+
+---
+
+### is-message-pinned
+
+Checks whether a message is currently pinned (pin has not expired).
+
+```clarity
+(define-read-only (is-message-pinned (message-id uint)))
+```
 
 **Returns:** `bool`
-- true if user has reacted, false otherwise
+
+---
+
+### is-message-deleted
+
+Checks whether a message has been soft-deleted.
+
+```clarity
+(define-read-only (is-message-deleted (message-id uint)))
+```
+
+**Returns:** `bool`
+
+---
+
+### get-user-stats
+
+Gets posting statistics for a user.
+
+```clarity
+(define-read-only (get-user-stats (user principal)))
+```
+
+**Returns:** `(optional { messages-posted: uint, total-spent: uint, last-post-block: uint })`
+
+---
+
+### get-user-profile
+
+Gets the profile data for a user.
+
+```clarity
+(define-read-only (get-user-profile (user principal)))
+```
+
+**Returns:** `(optional { display-name: (string-utf8 50), updated-at: uint })`
+
+---
+
+### get-display-name
+
+Gets only the display name for a user.
+
+```clarity
+(define-read-only (get-display-name (user principal)))
+```
+
+**Returns:** `(optional (string-utf8 50))` -- the display name or `none`
+
+---
+
+### get-total-messages
+
+```clarity
+(define-read-only (get-total-messages))
+```
+
+**Returns:** `(ok uint)` -- total messages posted (including deleted)
+
+---
+
+### get-total-deleted
+
+```clarity
+(define-read-only (get-total-deleted))
+```
+
+**Returns:** `(ok uint)` -- total messages that have been deleted
+
+---
+
+### get-total-edits
+
+```clarity
+(define-read-only (get-total-edits))
+```
+
+**Returns:** `(ok uint)` -- total edits across all messages
+
+---
+
+### get-total-replies
+
+```clarity
+(define-read-only (get-total-replies))
+```
+
+**Returns:** `(ok uint)` -- total reply messages
+
+---
+
+### get-total-fees-collected
+
+```clarity
+(define-read-only (get-total-fees-collected))
+```
+
+**Returns:** `(ok uint)` -- total fees collected in microSTX
+
+---
+
+### get-message-nonce
+
+Returns the current message nonce (equal to the next message ID).
+
+```clarity
+(define-read-only (get-message-nonce))
+```
+
+**Returns:** `(ok uint)`
+
+---
+
+### get-contract-stats
+
+Returns all key counters in a single call for efficient dashboard rendering.
+
+```clarity
+(define-read-only (get-contract-stats))
+```
+
+**Returns:**
+```clarity
+(ok {
+  total-messages: uint,
+  total-deleted: uint,
+  total-edits: uint,
+  total-replies: uint,
+  total-fees-collected: uint,
+  message-nonce: uint,
+  paused: bool
+})
+```
+
+---
+
+### get-page-range
+
+Calculates start and end message IDs for a given page number and page size.
+
+```clarity
+(define-read-only (get-page-range (page uint) (page-size uint)))
+```
+
+**Parameters:**
+| Name | Type | Description |
+|------|------|-------------|
+| `page` | `uint` | Page number (0-indexed) |
+| `page-size` | `uint` | Number of messages per page |
+
+**Returns:**
+```clarity
+(ok { start-id: uint, end-id: uint, total: uint })
+```
+
+---
+
+### has-user-reacted
+
+```clarity
+(define-read-only (has-user-reacted (message-id uint) (user principal)))
+```
+
+**Returns:** `bool`
+
+---
+
+### get-user-reaction-type
+
+Gets the reaction type a user submitted for a message.
+
+```clarity
+(define-read-only (get-user-reaction-type (message-id uint) (user principal)))
+```
+
+**Returns:** `(optional uint)` -- the reaction type, or `none` if user has not reacted
+
+---
+
+### get-reaction-count-by-type
+
+Gets the total count of a specific reaction type on a message.
+
+```clarity
+(define-read-only (get-reaction-count-by-type (message-id uint) (reaction-type uint)))
+```
+
+**Returns:** `uint`
+
+---
+
+### get-reply-parent / is-reply
+
+```clarity
+(define-read-only (get-reply-parent (message-id uint)))
+;; Returns (response uint uint) -- parent ID or err-not-found
+
+(define-read-only (is-reply (message-id uint)))
+;; Returns (response bool uint) -- true if reply-to > 0
+```
+
+---
+
+### get-edit-history
+
+Retrieves a previous version of an edited message.
+
+```clarity
+(define-read-only (get-edit-history (message-id uint) (edit-index uint)))
+```
+
+**Returns:** `(optional { previous-content: (string-utf8 280), edited-at-block: uint })`
+
+---
+
+### is-contract-paused
+
+```clarity
+(define-read-only (is-contract-paused))
+```
+
+**Returns:** `bool`
+
+---
+
+### get-contract-owner
+
+```clarity
+(define-read-only (get-contract-owner))
+```
+
+**Returns:** `(ok principal)`
+
+---
+
+### get-proposed-owner
+
+```clarity
+(define-read-only (get-proposed-owner))
+```
+
+**Returns:** `(ok (optional principal))`
+
+---
+
+### Fee Getters
+
+```clarity
+(define-read-only (get-fee-post-message))   ;; (ok uint)
+(define-read-only (get-fee-pin-24hr))       ;; (ok uint)
+(define-read-only (get-fee-pin-72hr))       ;; (ok uint)
+(define-read-only (get-fee-reaction))       ;; (ok uint)
+```
 
 ---
 
 ## Data Structures
 
-### Message
+### Message Map
+
+Key: `{ message-id: uint }`
+
 ```clarity
 {
   author: principal,
@@ -130,11 +684,19 @@ Check if user has reacted to a message.
   expires-at: uint,
   pinned: bool,
   pin-expires-at: uint,
-  reaction-count: uint
+  reaction-count: uint,
+  deleted: bool,
+  edited: bool,
+  edit-count: uint,
+  reply-to: uint,
+  reply-count: uint
 }
 ```
 
-### User Stats
+### User Stats Map
+
+Key: `{ user: principal }`
+
 ```clarity
 {
   messages-posted: uint,
@@ -143,10 +705,46 @@ Check if user has reacted to a message.
 }
 ```
 
-### Reaction
+### User Profiles Map
+
+Key: `principal`
+
 ```clarity
 {
-  reacted: bool
+  display-name: (string-utf8 50),
+  updated-at: uint
+}
+```
+
+### Reactions Map
+
+Key: `{ message-id: uint, user: principal }`
+
+```clarity
+{
+  reacted: bool,
+  reaction-type: uint
+}
+```
+
+### Typed Reaction Counts Map
+
+Key: `{ message-id: uint, reaction-type: uint }`
+
+```clarity
+{
+  count: uint
+}
+```
+
+### Edit History Map
+
+Key: `{ message-id: uint, edit-index: uint }`
+
+```clarity
+{
+  previous-content: (string-utf8 280),
+  edited-at-block: uint
 }
 ```
 
@@ -154,110 +752,193 @@ Check if user has reacted to a message.
 
 ## Error Codes
 
-- `u100`: Owner only
-- `u101`: Not found
-- `u102`: Unauthorized
-- `u103`: Invalid input
-- `u104`: Message expired
-- `u105`: Already reacted
+| Code | Constant | Description |
+|------|----------|-------------|
+| `u100` | `err-owner-only` | Caller is not the contract owner |
+| `u101` | `err-not-found` | Message not found |
+| `u102` | `err-unauthorized` | Not authorized for this action |
+| `u103` | `err-invalid-input` | Invalid input (empty message, bad length, fee out of range) |
+| `u104` | `err-max-edits-reached` | Message has reached the 10-edit limit |
+| `u105` | `err-already-reacted` | User already reacted to this message |
+| `u106` | `err-too-soon` | Must wait 6 blocks between posts (spam prevention) |
+| `u107` | `err-contract-paused` | Contract is paused by the owner |
+| `u108` | `err-insufficient-balance` | Not enough STX for the transaction fee |
+| `u109` | `err-already-deleted` | Message has already been deleted |
+| `u110` | `err-no-pending-transfer` | No ownership transfer is pending |
+| `u111` | `err-not-proposed-owner` | Caller is not the proposed new owner |
 
 ---
 
-## Fee Summary
+## Constants
 
-| Action | Fee (STX) | Fee (µSTX) |
-|--------|-----------|-----------|
-| Post Message | 0.00001 | 10,000 |
-| Pin 24 Hours | 0.00005 | 50,000 |
-| Pin 72 Hours | 0.0001 | 100,000 |
-| React | 0.000005 | 5,000 |
+### Configuration
 
----
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `min-message-length` | `u1` | Minimum message content length |
+| `max-message-length` | `u280` | Maximum message content length |
+| `default-expiry-blocks` | `u144` | Default message lifetime (~24 hours) |
+| `pin-24hr-blocks` | `u144` | 24-hour pin duration in blocks |
+| `pin-72hr-blocks` | `u432` | 72-hour pin duration in blocks |
+| `min-post-gap` | `u6` | Minimum blocks between posts (~1 hour) |
+| `max-edit-count` | `u10` | Maximum number of edits per message |
+| `min-fee` | `u1000` | Minimum allowed fee setting (0.001 STX) |
+| `max-fee` | `u10000000` | Maximum allowed fee setting (10 STX) |
 
-## Transaction Types (Leaderboard Metrics)
+### Reaction Types
 
-The contract supports **3 distinct transaction types** for maximizing on-chain activity:
-
-1. **post-message** - Core content creation
-2. **pin-message** - Premium visibility feature
-3. **react-to-message** - Engagement mechanism
-
-All transactions generate fees tracked in `total-fees-collected`.
-
----
-
-## Testing
-
-### Running Tests
-
-```bash
-npm test
-```
-
-### Test Coverage
-
-- ✅ Post message validation (length, fees, stats)
-- ✅ Pin message authorization and fees
-- ✅ Reaction duplicate prevention
-- ✅ Read-only function accuracy
-- ✅ Fee collection tracking
-- ✅ User statistics updates
-
-### Testnet Deployment
-
-See [Testnet Deployment Guide](../deployments/deploy-testnet.md)
-
-### Contract Address
-
-**Testnet (v3 - LIVE)**: `ST1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK1GA0CF0.message-board-v3`
-- **Deployment Date**: February 8, 2026
-- **Status**: Testing Phase (7-14 days)
-- **Clarity Version**: 2 (Epoch 2.1+)
-- **Features**: Security-enhanced, fee collection enabled, spam prevention, pause mechanism
-
-**Mainnet**: `[PENDING TESTNET VALIDATION]`
-
-**Testnet Explorer**: https://explorer.hiro.so/address/ST1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK1GA0CF0?chain=testnet
+| Constant | Value | Emoji |
+|----------|-------|-------|
+| `reaction-type-like` | `u1` | Like |
+| `reaction-type-fire` | `u2` | Fire |
+| `reaction-type-laugh` | `u3` | Laugh |
+| `reaction-type-sad` | `u4` | Sad |
+| `reaction-type-dislike` | `u5` | Dislike |
+| `max-reaction-type` | `u5` | Upper bound |
 
 ---
 
-## CLI Testing on Testnet
+## Fee Structure
 
-### Quick Test - Post Message
+Default fees (adjustable by the contract owner within `u1000`-`u10000000` range):
 
-```bash
-stx call-contract ST1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK1GA0CF0 message-board-v3 post-message \
-  -p message="\"Hello BitChat v3!\"" \
-  --testnet
-```
+| Action | Default (uSTX) | Default (STX) |
+|--------|----------------|---------------|
+| Post Message | 10,000 | 0.01 |
+| Pin 24 Hours | 50,000 | 0.05 |
+| Pin 72 Hours | 100,000 | 0.10 |
+| React to Message | 5,000 | 0.005 |
 
-### Read Message
+Use `get-fee-post-message`, `get-fee-pin-24hr`, `get-fee-pin-72hr`, and `get-fee-reaction` to query current fees on-chain.
 
-```bash
-stx call-read-only ST1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK1GA0CF0 message-board-v3 get-message \
-  -p message-id=u1 \
-  --testnet
-```
+---
 
-### Get Total Messages
+## Integration Guide
 
-```bash
-stx call-read-only ST1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK1GA0CF0 message-board-v3 get-total-messages \
-  --testnet
-```
-
-### Check Contract Status
+### Install Dependencies
 
 ```bash
-stx call-read-only ST1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK1GA0CF0 message-board-v3 is-contract-paused \
-  --testnet
+npm install @stacks/connect @stacks/transactions @stacks/network
 ```
 
-### Get Fees Collected
+### Network and Contract Config
 
-```bash
-stx call-read-only ST1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK1GA0CF0 message-board-v3 get-total-fees-collected \
-  --testnet
+```javascript
+import { StacksMainnet } from '@stacks/network';
+
+const network = new StacksMainnet();
+const CONTRACT_ADDRESS = 'SP1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK0DYG193';
+const CONTRACT_NAME = 'message-board-v3';
 ```
 
-For comprehensive testing guide, see [TESTNET_LIVE.md](../TESTNET_LIVE.md)
+### Reading Data
+
+```javascript
+import { callReadOnlyFunction, uintCV, cvToJSON } from '@stacks/transactions';
+
+const fetchMessage = async (id) => {
+  const result = await callReadOnlyFunction({
+    contractAddress: CONTRACT_ADDRESS,
+    contractName: CONTRACT_NAME,
+    functionName: 'get-message',
+    functionArgs: [uintCV(id)],
+    senderAddress: CONTRACT_ADDRESS,
+  });
+  return cvToJSON(result);
+};
+
+const fetchStats = async () => {
+  const result = await callReadOnlyFunction({
+    contractAddress: CONTRACT_ADDRESS,
+    contractName: CONTRACT_NAME,
+    functionName: 'get-contract-stats',
+    functionArgs: [],
+    senderAddress: CONTRACT_ADDRESS,
+  });
+  return cvToJSON(result);
+};
+```
+
+### Posting a Message
+
+```javascript
+import { openContractCall } from '@stacks/connect';
+import { stringUtf8CV } from '@stacks/transactions';
+
+const postMessage = async (content) => {
+  await openContractCall({
+    contractAddress: CONTRACT_ADDRESS,
+    contractName: CONTRACT_NAME,
+    functionName: 'post-message',
+    functionArgs: [stringUtf8CV(content)],
+    postConditionMode: 0x01,
+    onFinish: ({ txId }) => {
+      console.log('Submitted:', txId);
+    },
+  });
+};
+```
+
+### Replying to a Message
+
+```javascript
+import { uintCV, stringUtf8CV } from '@stacks/transactions';
+
+const replyToMessage = async (parentId, content) => {
+  await openContractCall({
+    contractAddress: CONTRACT_ADDRESS,
+    contractName: CONTRACT_NAME,
+    functionName: 'reply-to-message',
+    functionArgs: [uintCV(parentId), stringUtf8CV(content)],
+    postConditionMode: 0x01,
+    onFinish: ({ txId }) => console.log('Reply TX:', txId),
+  });
+};
+```
+
+### Paginated Fetching
+
+```javascript
+const fetchPage = async (page, pageSize = 10) => {
+  const range = await callReadOnlyFunction({
+    contractAddress: CONTRACT_ADDRESS,
+    contractName: CONTRACT_NAME,
+    functionName: 'get-page-range',
+    functionArgs: [uintCV(page), uintCV(pageSize)],
+    senderAddress: CONTRACT_ADDRESS,
+  });
+
+  const parsed = cvToJSON(range).value;
+  const startId = parsed['start-id'].value;
+  const endId = parsed['end-id'].value;
+  const messages = [];
+
+  for (let id = startId; id <= endId; id++) {
+    const msg = await fetchMessage(id);
+    if (msg.value) messages.push(msg.value);
+  }
+
+  return messages;
+};
+```
+
+### Checking Transaction Status
+
+```javascript
+const checkTx = async (txId) => {
+  const res = await fetch(
+    `https://stacks-node-api.mainnet.stacks.co/extended/v1/tx/${txId}`
+  );
+  const data = await res.json();
+  return data.tx_status; // 'pending', 'success', 'abort_by_response'
+};
+```
+
+---
+
+## Contract Links
+
+- **Explorer:** [View on Stacks Explorer](https://explorer.stacks.co/txid/SP1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK0DYG193.message-board-v3?chain=mainnet)
+- **Source Code:** [contracts/message-board.clar](../contracts/message-board.clar)
+- **Tests:** [tests/](../tests/)
+- **Frontend:** [frontend/](../frontend/)


### PR DESCRIPTION
Closes #34

The existing CONTRACT_API.md was outdated and only covered 3 public functions and 6 read-only functions from the original contract version.

This rewrite covers the full v3 contract surface:

**Public Functions (18):**
- post-message, pin-message, react-to-message, react-to-message-typed
- reply-to-message, edit-message, delete-message, set-display-name
- withdraw-fees, pause/unpause-contract
- propose-ownership-transfer, accept-ownership, cancel-ownership-transfer
- set-fee-post-message, set-fee-pin-24hr, set-fee-pin-72hr, set-fee-reaction

**Read-Only Functions (29):**
- get-message, get-active-message, is-message-expired/pinned/deleted
- get-user-stats, get-user-profile, get-display-name
- get-total-messages/deleted/edits/replies, get-total-fees-collected
- get-contract-stats, get-page-range, get-message-nonce
- has-user-reacted, get-user-reaction-type, get-reaction-count-by-type
- get-reply-parent, is-reply, get-edit-history
- is-contract-paused, get-contract-owner, get-proposed-owner
- Fee getters (4)

**Also added:**
- All 6 data map structures with key/value types
- Error codes table (u100-u111, all 12 codes)
- Constants reference (config + reaction types)
- Fee structure with defaults and adjustable range
- Integration guide with JavaScript examples
- Table of contents for navigation
- Correct mainnet contract address